### PR TITLE
Update container images and version for aitestmate to 1.8.7

### DIFF
--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-api
 description: AI TestMate API Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/README.md
@@ -1,6 +1,6 @@
 # aitestmate-api
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate API Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-beat/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-beat/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-beat
 description: AI TestMate Beat Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-beat/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-beat/README.md
@@ -1,6 +1,6 @@
 # aitestmate-beat
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Beat Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-elasticsearch/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-elasticsearch/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-elasticsearch
 description: AI TestMate Elasticsearch Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-elasticsearch/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-elasticsearch/README.md
@@ -1,6 +1,6 @@
 # aitestmate-elasticsearch
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Elasticsearch Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-embeddings/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-embeddings/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-embeddings
 description: AI TestMate Embeddings Helm chart for Kubernetes
 
 type: application
-version: "0.1.2"
-appVersion: "1.2.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-embeddings/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-embeddings/README.md
@@ -1,6 +1,6 @@
 # aitestmate-embeddings
 
-![Version: 0.1.2](https://img.shields.io/badge/Version-0.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Embeddings Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-flower/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-flower/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-flower
 description: AI TestMate Flower Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-flower/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-flower/README.md
@@ -1,6 +1,6 @@
 # aitestmate-flower
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Flower Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-kibana/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-kibana/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-kibana
 description: AI TestMate Kibana Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-kibana/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-kibana/README.md
@@ -1,6 +1,6 @@
 # aitestmate-kibana
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Kibana Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-migrator/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-migrator/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-migrator
 description: AI TestMate Migrator Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-migrator/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-migrator/README.md
@@ -1,6 +1,6 @@
 # aitestmate-migrator
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Migrator Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-migrator/templates/job.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-migrator/templates/job.yaml
@@ -38,7 +38,6 @@ spec:
             {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: >-
             {{ .Values.image.pullPolicy }}
-          args: ["database", "migrate"]
           # {{ with (concat (default list .Values.env) (default list .Values.extraEnv) | uniq) }}
           env:
             # {{ toYaml . | nindent 12 }}

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-nginx
 description: AI TestMate Nginx Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/README.md
@@ -1,6 +1,6 @@
 # aitestmate-nginx
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Nginx Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-rabbitmq/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-rabbitmq/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-rabbitmq
 description: AI TestMate RabbitMQ Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-rabbitmq/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-rabbitmq/README.md
@@ -1,6 +1,6 @@
 # aitestmate-rabbitmq
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate RabbitMQ Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-redis/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-redis/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-redis
 description: AI TestMate Redis Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-redis/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-redis/README.md
@@ -1,6 +1,6 @@
 # aitestmate-redis
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Redis Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-sysworker/Chart.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-sysworker/Chart.yaml
@@ -3,5 +3,5 @@ name: aitestmate-sysworker
 description: AI TestMate Sys Worker Helm chart for Kubernetes
 
 type: application
-version: "0.1.6"
-appVersion: "1.8.0"
+version: "0.2.0"
+appVersion: "1.8.7"

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-sysworker/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-sysworker/README.md
@@ -1,6 +1,6 @@
 # aitestmate-sysworker
 
-![Version: 0.1.6](https://img.shields.io/badge/Version-0.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.0](https://img.shields.io/badge/AppVersion-1.8.0-informational?style=flat-square)
+![Version: 0.2.0](https://img.shields.io/badge/Version-0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.8.7](https://img.shields.io/badge/AppVersion-1.8.7-informational?style=flat-square)
 
 AI TestMate Sys Worker Helm chart for Kubernetes
 

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-sysworker/templates/deployment.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-sysworker/templates/deployment.yaml
@@ -39,7 +39,6 @@ spec:
             {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
           imagePullPolicy: >-
             {{ .Values.image.pullPolicy }}
-          args: ["worker", "run", "--queues", "system_tasks"]
           # {{ with (concat (default list .Values.env) (default list .Values.extraEnv) | uniq) }}
           env:
             # {{ toYaml . | nindent 12 }}


### PR DESCRIPTION
NOTE: This PR requires aitestmate >= 1.8.5

In new version dedicated containers were added for:
- migrator
- sysworker
- embeddings