### PR TITLE
AI/RUN TestMate API Ingress

### DIFF
--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/README.md
@@ -28,6 +28,11 @@ AI TestMate API Helm chart for Kubernetes
 | image.repository | string | `"000000000000.dkr.ecr.us-east-1.amazonaws.com/epam-systems/add-ons/aitestmate/api"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
+| ingress.annotations | object | `{}` |  |
+| ingress.className | string | `""` |  |
+| ingress.enabled | bool | `false` |  |
+| ingress.hosts | list | `[]` |  |
+| ingress.tls | list | `[]` |  |
 | livenessProbe | object | `{}` |  |
 | nameOverride | string | `"aitestmate-api"` |  |
 | nodeSelector | object | `{}` |  |

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/examples/aws/values.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/examples/aws/values.yaml
@@ -63,6 +63,26 @@ serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::000000000000:role/aitestmate-api-role
 
+# It is recommended to expose AI TestMate via Codemie
+ingress:
+  enabled: true
+  className: nginx
+  annotations:
+    nginx.ingress.kubernetes.io/auth-response-headers: X-Auth-Request-Access-Token,Authorization
+    nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start?rd=$escaped_request_uri
+    nginx.ingress.kubernetes.io/auth-url: http://oauth2-proxy.oauth2-proxy.svc.cluster.local:80/oauth2/auth
+    nginx.ingress.kubernetes.io/proxy-body-size: 900m
+    nginx.ingress.kubernetes.io/proxy-buffer-size: 64k
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "600"
+
+  hosts:
+    - host: codemie.example.com
+      paths:
+        - path: /aitestmate/api
+          pathType: ImplementationSpecific
+        - path: /aitestmate/auth
+          pathType: ImplementationSpecific
+
 resources:
   requests:
     cpu: 1000m

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/templates/ingress.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/templates/ingress.yaml
@@ -1,43 +1,52 @@
-{{- if .Values.ingress.enabled -}}
+---
+
+# {{ if .Values.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "aitestmate-api.fullname" . }}
+  name: aitestmate-api
   labels:
-    {{- include "aitestmate-api.labels" . | nindent 4 }}
-  {{- with .Values.ingress.annotations }}
+    # {{ include "aitestmate-api.labels" . | nindent 4 }}
+  # {{ with .Values.ingress.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+    # {{ toYaml . | nindent 4 }}
+  # {{ end }}
 spec:
-  {{- with .Values.ingress.className }}
-  ingressClassName: {{ . }}
-  {{- end }}
-  {{- if .Values.ingress.tls }}
+  # {{ with .Values.ingress.className }}
+  ingressClassName: >-
+    {{ . }}
+  # {{ end }}
+  # {{ if .Values.ingress.tls }}
   tls:
-    {{- range .Values.ingress.tls }}
+    # {{ range .Values.ingress.tls }}
     - hosts:
-        {{- range .hosts }}
-        - {{ . | quote }}
-        {{- end }}
-      secretName: {{ .secretName }}
-    {{- end }}
-  {{- end }}
+        # {{ range .hosts }}
+        - >-
+         {{ . }}
+        # {{ end }}
+      secretName: >-
+        {{ .secretName }}
+    # {{ end }}
+  # {{ end }}
   rules:
-    {{- range .Values.ingress.hosts }}
-    - host: {{ .host | quote }}
+    # {{ range .Values.ingress.hosts }}
+    - host: >-
+        {{ .host }}
       http:
         paths:
-          {{- range .paths }}
-          - path: {{ .path }}
-            {{- with .pathType }}
-            pathType: {{ . }}
-            {{- end }}
+          # {{ range .paths }}
+          - path: >-
+              {{ .path }}
+            # {{ with .pathType }}
+            pathType: >-
+              {{ . }}
+            # {{ end }}
             backend:
               service:
-                name: {{ include "aitestmate-api.fullname" $ }}
+                name: aitestmate-api
                 port:
-                  number: {{ $.Values.service.port }}
-          {{- end }}
-    {{- end }}
-{{- end }}
+                  number:
+                    {{ $.Values.service.port }}
+          # {{ end }}
+    # {{ end }}
+# {{ end }}

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/values.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-api/values.yaml
@@ -160,18 +160,29 @@ service:
   # This sets the ports more information can be found here: https://kubernetes.io/docs/concepts/services-networking/service/#field-spec-ports
   port: 8280
 
-# @ignore -- not implemented yet
+# Ingress could be enabled to serve aitestmate directly or behind codemie
 ingress:
   enabled: false
   className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
+  hosts: []
+    # Expose it directly (not recommended)
+    # - host: aitestmate.example.com
+    #   paths:
+    #     - path: /api
+    #       pathType: ImplementationSpecific
+    #     - path: /auth
+    #       pathType: ImplementationSpecific
+    #
+    # Expose it via codemie
+    # - host: codemie.example.com
+    #   paths:
+    #     - path: /aitestmate/api
+    #       pathType: ImplementationSpecific
+    #     - path: /aitestmate/auth
+    #       pathType: ImplementationSpecific
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/README.md
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/README.md
@@ -9,7 +9,7 @@ AI TestMate Nginx Helm chart for Kubernetes
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| env[0] | object | `{"name":"AITESTMATE_NGINX_UPSTREAM0","value":"aitestmate-api:8280"}` | proxy backend requests to api |
+| env[0] | object | `{"name":"AITESTMATE_NGINX_UPSTREAM0","value":"aitestmate-api:8280"}` | proxy backend requests to api when no explicit ingress |
 | extraEnv | list | `[]` | Additional environment passed into container |
 | fullnameOverride | string | `"aitestmate-nginx"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/examples/aws/values.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/examples/aws/values.yaml
@@ -21,12 +21,7 @@ ingress:
   hosts:
     - host: codemie.example.com
       paths:
-        - backend:
-            service:
-              name: aitestmate-nginx
-              port:
-                number: 80
-          path: /aitestmate
+        - path: /aitestmate
           pathType: ImplementationSpecific
 
 # Set resources for aitestmate-nginx

--- a/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/values.yaml
+++ b/deployment/add-ons/aitestmate/helm-scripts/charts/aitestmate-nginx/values.yaml
@@ -18,7 +18,7 @@ nameOverride: "aitestmate-nginx"
 fullnameOverride: "aitestmate-nginx"
 
 env:
-  # -- proxy backend requests to api
+  # -- proxy backend requests to api when no explicit ingress
   - name: AITESTMATE_NGINX_UPSTREAM0
     value: aitestmate-api:8280
 


### PR DESCRIPTION
This also prevents bug when nginx caches DNS for upstream service, but k8s service changes its internal IP.